### PR TITLE
Update preloader timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,8 @@
       }
     }
 
-    window.addEventListener("load", function () {
+    // Appena il DOM è pronto, avviamo il timer del preloader
+    window.addEventListener("DOMContentLoaded", function () {
       const preloader = document.getElementById("preloader");
 
       // 3 secondi di tempo visibile al preloader, poi dissolve


### PR DESCRIPTION
## Summary
- trigger the preloader removal when DOMContentLoaded fires
- keep 3s timer so fadeout happens without waiting for audio load

## Testing
- `node test-preloader.js` (after installing puppeteer)

------
https://chatgpt.com/codex/tasks/task_e_684002019ec8832f9fdff3287d022d47